### PR TITLE
Added getConnectedIp Function

### DIFF
--- a/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
+++ b/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
@@ -150,6 +150,30 @@ namespace CTRE
                     return temp;
                 }
 
+                public string getConnectedIp(int timeoutMs = 100)
+                {
+                    byte[] toSend = MakeByteArrayFromString("AT+CIFSR" + "\r\n");
+
+                    int err = transaction(toSend, timeoutMs);
+
+                    string temp = "";
+
+                    if (err == 0)
+                    {
+                        foreach (String x in lines)
+                        {
+                            if (x.Length >= 12 && x.Substring(0, 12) == "+CIFSR:STAIP")
+                            {
+                                temp = x.Substring(14);
+                                int tempLen = temp.Length - 1;
+                                temp = temp.Substring(0, tempLen).ToString();
+                            }
+                        }
+                    }
+
+                    return temp;
+                }
+
                 public int setWifiMode(wifiMode mode, int timeoutMs = 50)
                 {
                     byte[] toSend = MakeByteArrayFromString("AT+CWMODE_CUR=" + mode + "\r\n");


### PR DESCRIPTION
Added getConnectedIp to ESP12F WiFi Module.  Returns IP address as a string once device is connected.  Uses the AT+CIFSR command and does some formatting.  Probably a cleaner way to do this but it'll do.