### PR TITLE
Methods to get IP Addresses of ESP12F (SoftAP + Station)

### DIFF
--- a/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
+++ b/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
@@ -190,7 +190,7 @@ namespace CTRE
                                     /* start with char after first quote */
                                     temp = temp.Substring(start + 1, len);
                                     /* leave for loop immedietely since IP has been found */
-                                    return temp
+                                    return temp;
                                 }
                             }
                         }
@@ -237,7 +237,7 @@ namespace CTRE
                                     /* start with char after first quote */
                                     temp = temp.Substring(start + 1, len);
                                     /* leave for loop immedietely since IP has been found */
-                                    return temp
+                                    return temp;
                                 }
                             }
                         }

--- a/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
+++ b/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
@@ -174,19 +174,23 @@ namespace CTRE
                         {
                             if (x.Length >= 12 && x.Substring(0, 12) == "+CIFSR:STAIP")
                             {
+                                /* the line holding IP has been found, copy it out */
                                 temp = x.ToString();
-
+                                /* crop out everything between quotes */
                                 int start = temp.IndexOf('\"');
                                 int end = temp.LastIndexOf('\"');
-                                if (start <= -1 || end <= -1 || (start + (end - start)) > temp.Length)
+                                int len = end - start - 1; /* chars between quotes not including quotes themselves */
+                                /* validate input, do not parse if garbage */
+                                if (start <= -1 || end <= -1 || len <= -1)
                                 {
-                                    /* Skip over if start, end, or length are invalid */
-                                    temp = "";
+                                    /* Leave temp as empty if start, end, or length are invalid */
                                 }
                                 else
                                 {
-                                    start += 1; // exclude the first index of character (Char itself)
-                                    temp = temp.Substring(start, end - start);
+                                    /* start with char after first quote */
+                                    temp = temp.Substring(start + 1, len);
+                                    /* leave for loop immedietely since IP has been found */
+                                    return temp
                                 }
                             }
                         }
@@ -217,19 +221,23 @@ namespace CTRE
                         {
                             if (x.Length >= 11 && x.Substring(0, 11) == "+CIFSR:APIP")
                             {
+                                /* the line holding IP has been found, copy it out */
                                 temp = x.ToString();
-
+                                /* crop out everything between quotes */
                                 int start = temp.IndexOf('\"');
                                 int end = temp.LastIndexOf('\"');
-                                if(start <= -1 || end <= -1 || (start + (end - start)) > temp.Length)
+                                int len = end - start - 1; /* chars between quotes not including quotes themselves */
+                                /* validate input, do not parse if garbage */
+                                if (start <= -1 || end <= -1 || len <= -1)
                                 {
-                                    /* Skip over if start, end, or length are invalid */
-                                    temp = "";
+                                    /* Leave temp as empty if start, end, or length are invalid */
                                 }
                                 else
                                 {
-                                    start += 1; // exclude the first index of character (Char itself)
-                                    temp = temp.Substring(start, end - start);
+                                    /* start with char after first quote */
+                                    temp = temp.Substring(start + 1, len);
+                                    /* leave for loop immedietely since IP has been found */
+                                    return temp
                                 }
                             }
                         }

--- a/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
+++ b/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
@@ -150,27 +150,90 @@ namespace CTRE
                     return temp;
                 }
 
-                public string getConnectedIp(int timeoutMs = 100)
+                /**
+                 * Get the Station IP Address
+                 *
+                 * @param timeoutMs
+                 *            Timeout value in ms. If nonzero, function will wait for
+                 *            config success and report an error if it times out.
+                 *            If zero, no blocking or checking is performed.
+                 * @return String of the IP Address
+                 *            If in Station Mode, we check the first 12 characters to match 
+                 *            "+CIFSR:STAIP". 
+                 */
+                public String getStationIP(int timeoutMs = 100)
                 {
                     byte[] toSend = MakeByteArrayFromString("AT+CIFSR" + "\r\n");
 
                     int err = transaction(toSend, timeoutMs);
 
-                    string temp = "";
-
+                    string temp = "";   /* Return empty string if there is no response */
                     if (err == 0)
                     {
                         foreach (String x in lines)
                         {
                             if (x.Length >= 12 && x.Substring(0, 12) == "+CIFSR:STAIP")
                             {
-                                temp = x.Substring(14);
-                                int tempLen = temp.Length - 1;
-                                temp = temp.Substring(0, tempLen).ToString();
+                                temp = x.ToString();
+
+                                int start = temp.IndexOf('\"');
+                                int end = temp.LastIndexOf('\"');
+                                if (start <= -1 || end <= -1 || (start + (end - start)) > temp.Length)
+                                {
+                                    /* Skip over if start, end, or length are invalid */
+                                    temp = "";
+                                }
+                                else
+                                {
+                                    start += 1; // exclude the first index of character (Char itself)
+                                    temp = temp.Substring(start, end - start);
+                                }
                             }
                         }
                     }
+                    return temp;
+                }
 
+                /* Get the Access Point IP Address
+                 *
+                 * @param timeoutMs
+                 * Timeout value in ms.If nonzero, function will wait for
+                 *            config success and report an error if it times out.
+                 *            If zero, no blocking or checking is performed.
+                 * @return String of the IP Address
+                 *            If in softAP Mode, we check the first 11 characters to match
+                 *            "+CIFSR:APIP"
+                 */
+                public String getAccessPointIP(int timeoutMs = 100)
+                {
+                    byte[] toSend = MakeByteArrayFromString("AT+CIFSR" + "\r\n");
+
+                    int err = transaction(toSend, timeoutMs);
+
+                    string temp = "";   /* Return empty string if there is no response */
+                    if (err == 0)
+                    {
+                        foreach (String x in lines)
+                        {
+                            if (x.Length >= 11 && x.Substring(0, 11) == "+CIFSR:APIP")
+                            {
+                                temp = x.ToString();
+
+                                int start = temp.IndexOf('\"');
+                                int end = temp.LastIndexOf('\"');
+                                if(start <= -1 || end <= -1 || (start + (end - start)) > temp.Length)
+                                {
+                                    /* Skip over if start, end, or length are invalid */
+                                    temp = "";
+                                }
+                                else
+                                {
+                                    start += 1; // exclude the first index of character (Char itself)
+                                    temp = temp.Substring(start, end - start);
+                                }
+                            }
+                        }
+                    }
                     return temp;
                 }
 

--- a/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
+++ b/CTRE/Gadgeteer/Modules/WiFiESP12F.cs
@@ -150,6 +150,30 @@ namespace CTRE
                     return temp;
                 }
 
+                public string getConnectedIp(int timeoutMs = 100)
+                {
+                    byte[] toSend = MakeByteArrayFromString("AT+CIFSR" + "\r\n");
+
+                    int err = transaction(toSend, timeoutMs);
+
+                    string temp = "";
+
+                    if (err == 0)
+                    {
+                        foreach (String x in lines)
+                        {
+                            if (x.Length >= 12 && x.Substring(0, 12) == "+CIFSR:STAIP")
+                            {
+                                temp = x.Substring(14);
+                                int tempLen = temp.Length - 1;
+                                temp = temp.Substring(0, tempLen).ToString();
+                            }
+                        }
+                    }
+
+                    return temp;
+                }
+
                 public int setWifiMode(wifiMode mode, int timeoutMs = 50)
                 {
                     byte[] toSend = MakeByteArrayFromString("AT+CWMODE_CUR=" + mode + "\r\n");


### PR DESCRIPTION
+ Provides IP Addresses for the two modes, softAP and Station.
+ Called getAccessPointIP() and getStationIP(), respectively.
+ No longer looks at the length of string to parse
- Needs Errorcode reporting possibly?